### PR TITLE
fix: avoid recursive group refs in nodes map

### DIFF
--- a/src/stores/nodes.js
+++ b/src/stores/nodes.js
@@ -77,8 +77,16 @@ export const useNodesStore = defineStore('groups', {
     },
     actions:{
         setGroups(groups){
-            // 子组嵌套
-            let _groups = cloneDeep(groups.map(g => new Object({ id: g.id, pos: g.pos, size: g.size, title: g.title, pinned: g.pinned, nodes: g.nodes, children: g.children, show_nodes: g.show_nodes})))
+            // Only keep display fields here. Carrying runtime graph references
+            // like nodes/children into cloneDeep can recurse through nested groups.
+            let _groups = cloneDeep(groups.map(g => new Object({
+                id: g.id,
+                pos: Array.isArray(g.pos) ? [...g.pos] : g.pos,
+                size: Array.isArray(g.size) ? [...g.size] : g.size,
+                title: g.title,
+                pinned: g.pinned,
+                show_nodes: g.show_nodes
+            })))
             _groups.forEach(group => {
                 group.sub_groups = [];
                 _groups.forEach(innerGroup => {


### PR DESCRIPTION
## Summary
- avoid carrying runtime nodes/children references into the NodesMap store
- shallow-copy pos/size before cloning group metadata
- keep nested group rendering while avoiding recursive frontend cloning

## Why
NodesMap currently stores raw group fields including nodes and children, then cloneDeep()s them. On graphs with nested groups or recursive runtime references, opening NodesMap can trigger:

Uncaught RangeError: Maximum call stack size exceeded

This patch keeps only the display fields needed by NodesMap and rebuilds sub_groups from positions, which avoids recursively cloning graph internals.

## Notes
- source-only change in ComfyUI-Easy-Use-Frontend
- branch tested by reproducing the same runtime bundle patch in an installed EasyUse setup